### PR TITLE
Add Command line options to HackLinks Server

### DIFF
--- a/HackLinks Server/HackLinks Server.csproj
+++ b/HackLinks Server/HackLinks Server.csproj
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Mono.Options, Version=5.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Options.5.3.0.1\lib\net4-client\Mono.Options.dll</HintPath>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
+    </Reference>
     <Reference Include="MySql.Data, Version=6.10.5.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d, processorArchitecture=MSIL">
       <HintPath>..\packages\MySql.Data.6.10.5\lib\net452\MySql.Data.dll</HintPath>
     </Reference>

--- a/HackLinks Server/Program.cs
+++ b/HackLinks Server/Program.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Mono.Options;
 
 namespace HackLinks_Server
 {
@@ -23,12 +24,73 @@ namespace HackLinks_Server
 
         static void Main(string[] args)
         {
+
+            bool showHelp = false;
+
+            //Set Defaults
+            Server.Instance.MySQLServer = "127.0.0.1";
+            Server.Instance.Database = "hacklinks";
+            Server.Instance.UserID = "root";
+            Server.Instance.Password = "";
+
+            bool passSet = true;
+
+            //Handle Args
+            OptionSet options = new OptionSet() {
+                { "s|server=", "the MySQL {SERVER} to use (default: \"127.0.0.1\").", v => Server.Instance.MySQLServer = v},
+                { "d|database=", "the {DATABASE} to use (default: \"hacklinks\").", v => Server.Instance.Database = v},
+                { "u|user=", "the {USERNAME} to connect with (default: \"root\").", v => Server.Instance.UserID = v},
+                { "p|password:", "set the {PASSWORD} to connect with (default: None) or prompt for a password.", v => {passSet = v != null; Server.Instance.Password = v;} },
+                { "h|help",  "show this message and exit.", v => showHelp = v != null },
+            };
+
+            try
+            {
+                options.Parse(args);
+
+                if (showHelp) // If help requested then show help and exit
+                {
+                    Console.WriteLine("Usage: HackLinks Server.exe [OPTIONS]");
+                    Console.WriteLine("Starts the HackLinks Server.");
+                    Console.WriteLine();
+
+                    // output the options
+                    Console.WriteLine("Options:");
+                    options.WriteOptionDescriptions(Console.Out);
+
+                    return;
+                }
+
+                //Check if password is null and prompt if it is
+                //Done here to avoid asking for password when other options are going to fail anyway or help should be displayed.
+                if (!passSet)
+                    Server.Instance.Password = GetPassword();
+
+            } catch(OptionException e)
+            {
+                //One of our options failed. Output the message
+                Console.WriteLine(e.Message);
+                return;
+            }
+
             IPHostEntry ipHostInfo = Dns.Resolve(Dns.GetHostName());
             IPAddress ipAddress = ipHostInfo.AddressList[0];
             IPEndPoint localEndPoint = new IPEndPoint(ipAddress, 27015);
 
             Socket listener = new Socket(AddressFamily.InterNetwork,
                 SocketType.Stream, ProtocolType.Tcp);
+
+            try
+            {
+                Server.Instance.StartServer();
+            } catch(MySql.Data.MySqlClient.MySqlException e)
+            {
+                Console.WriteLine(e.Message);
+
+                Console.WriteLine("\nHit enter to continue...");
+                Console.Read();
+                return;
+            }
 
             try
             {
@@ -56,6 +118,24 @@ namespace HackLinks_Server
 
             Console.WriteLine("\nHit enter to continue...");
             Console.Read();
+        }
+
+        private static string GetPassword()
+        {
+            Console.Write("Please Enter Password:");
+
+            string password = string.Empty;
+
+            ConsoleKeyInfo keyInfo = Console.ReadKey(true);
+            while (keyInfo.Key != ConsoleKey.Enter)
+            {
+                password += keyInfo.KeyChar;
+                keyInfo = Console.ReadKey(true);
+            }
+
+            Console.WriteLine();
+
+            return password;
         }
 
         public static void AcceptCallback(IAsyncResult ar)

--- a/HackLinks Server/Server.cs
+++ b/HackLinks Server/Server.cs
@@ -22,17 +22,22 @@ namespace HackLinks_Server
 
         private ComputerManager computerManager;
 
+        //Connection String args
+        private MySqlConnectionStringBuilder connectionStringBuilder = new MySqlConnectionStringBuilder();
+        public string MySQLServer { get => connectionStringBuilder.Server; internal set => connectionStringBuilder.Server = value; }
+        public string Database { get => connectionStringBuilder.Database; internal set => connectionStringBuilder.Database = value; }
+        public string UserID { get => connectionStringBuilder.UserID; internal set => connectionStringBuilder.UserID = value; }
+        public string Password { get => connectionStringBuilder.Password; internal set => connectionStringBuilder.Password = value; }
 
         private Server()
         {
-
             clients = new List<GameClient>();
-            conn = new MySqlConnection();
-            conn.ConnectionString =
-            "Data Source=127.0.0.1;" +
-            "Initial Catalog=hacklinks;" +
-            "User id=root;" + //"User id=hacklinksServer;" +
-            "Password="; //"Password=cx4IDcbAOUhY16Ab;";
+        }
+
+        public void StartServer()
+        {
+            conn = new MySqlConnection(GetConnectionString());
+
             Console.WriteLine("Opening SQL connection");
             conn.Open();
             Console.WriteLine("SQL Running");
@@ -62,10 +67,7 @@ namespace HackLinks_Server
 
         public string GetConnectionString()
         {
-            return "Data Source=127.0.0.1;" +
-            "Initial Catalog=hacklinks;" +
-            "User id=root;" + //"User id=hacklinksServer;" +
-            "Password="; //"Password=cx4IDcbAOUhY16Ab;";
+            return connectionStringBuilder.GetConnectionString(true);
         }
 
         public void TreatMessage(GameClient client, string message)

--- a/HackLinks Server/packages.config
+++ b/HackLinks Server/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Mono.Options" version="5.3.0.1" targetFramework="net461" />
   <package id="MySql.Data" version="6.10.5" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Command line options have been added to allow easier testing on
other systems without editing the source code.
Should also make testing easier (e.g. hacklinks.exe -d testingdatabase)