### PR TITLE
Fix Server Listener so that clients can connect on localhost

### DIFF
--- a/HackLinks Server/Program.cs
+++ b/HackLinks Server/Program.cs
@@ -114,9 +114,7 @@ namespace HackLinks_Server
             Server.Instance.UserID = configData.UserID;
             Server.Instance.Password = configData.Password;
 
-            IPHostEntry ipHostInfo = Dns.Resolve(Dns.GetHostName());
-            IPAddress ipAddress = ipHostInfo.AddressList[0];
-            IPEndPoint localEndPoint = new IPEndPoint(ipAddress, 27015);
+            IPEndPoint localEndPoint = new IPEndPoint(IPAddress.Any, 27015);
 
             Socket listener = new Socket(AddressFamily.InterNetwork,
                 SocketType.Stream, ProtocolType.Tcp);


### PR DESCRIPTION
Previously the listening address was fixed to the internal network IP
Address of the system. This forced a local client to connect via that
rather than localhost/loopback addresses.