### PR TITLE
Fix/net/buffersize

### DIFF
--- a/HackLinks Server/ConfigUtil.cs
+++ b/HackLinks Server/ConfigUtil.cs
@@ -41,6 +41,7 @@ namespace HackLinks_Server
             public string Database { get; set; }
             public string UserID { get; set; }
             public string Password { get; set; }
+            public int Port { get; set; }
         }
     }
 

--- a/HackLinks Server/Program.cs
+++ b/HackLinks Server/Program.cs
@@ -33,6 +33,7 @@ namespace HackLinks_Server
             //Set Defaults and create config object
             ConfigUtil.ConfigData configData = new ConfigUtil.ConfigData();
             configData.MySQLServer = "127.0.0.1";
+            configData.Port = 27015;
             configData.Database = "hacklinks";
             configData.UserID = "root";
             configData.Password = "";
@@ -45,6 +46,21 @@ namespace HackLinks_Server
                 { "d|database=", "the {DATABASE} to use (default: \"hacklinks\").", v => configData.Database = v},
                 { "u|user=", "the {USERNAME} to connect with (default: \"root\").", v => configData.UserID = v},
                 { "p|password:", "set the {PASSWORD} to connect with (default: None) or prompt for a password.", v => {passSet = v != null;  configData.Password = v;} },
+                { "P|port=",
+                    "set the {PORT} to open the server on (default: 27015).",
+                    v =>
+                    {
+                        int result;
+                        if(int.TryParse(v, out result))
+                        {
+                            configData.Port = result;
+                        }
+                        else
+                        {
+                            Console.WriteLine("Invalid Port Specified: \"{0}\". Using Default Port.", v);
+                        }
+                    }
+                },
                 { "c|config:",
                     "load settings from {CONFIG} file (default: No) or from default config file \"serverconfig.conf\".\n" +
                     "If the file doesn't exist it will be created with the the final values when the server runs unless the {-o/--overwrite-config} flag specifies a file instead.",
@@ -116,7 +132,7 @@ namespace HackLinks_Server
 
             IPHostEntry ipHostInfo = Dns.Resolve(Dns.GetHostName());
             IPAddress ipAddress = ipHostInfo.AddressList[0];
-            IPEndPoint localEndPoint = new IPEndPoint(ipAddress, 27015);
+            IPEndPoint localEndPoint = new IPEndPoint(ipAddress, configData.Port);
 
             Socket listener = new Socket(AddressFamily.InterNetwork,
                 SocketType.Stream, ProtocolType.Tcp);

--- a/HackOnNet/ConfigUtil.cs
+++ b/HackOnNet/ConfigUtil.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.IO;
+
+namespace HackOnNet
+{
+    public static class ConfigUtil
+    {
+        /// <summary>
+        /// Load config from the given path into the given <see cref="ConfigData"/> Object.
+        /// Returns <c>true</c> if the file exists or <c>false</c> if it does not.
+        /// </summary>
+        /// <param name="path">The path to your config file</param>
+        /// <param name="conf">ConfigData Object to populate</param>   
+        /// <returns>If the file exists</returns>
+        public static bool LoadConfig(string path, ConfigData conf)
+        {
+            if(File.Exists(path))
+            {
+                // read file into a string and deserialize JSON
+                JsonConvert.PopulateObject(File.ReadAllText(path), conf);
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Save the config from the given <see cref="ConfigData"/> to the given path.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <param name="conf"></param>
+        public static void SaveConfig(string path, ConfigData conf)
+        {
+            // write config to a new file
+            File.WriteAllText(path, JsonConvert.SerializeObject(conf, Formatting.Indented));
+        }
+
+        public class ConfigData
+        {
+            public string ServerIP { get; set; }
+            public int Port { get; set; }
+        }
+    }
+
+
+}

--- a/HackOnNet/HackOnNet.csproj
+++ b/HackOnNet/HackOnNet.csproj
@@ -39,6 +39,9 @@
     <Reference Include="HacknetPathfinder">
       <HintPath>..\lib\HacknetPathfinder.exe</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="Pathfinder">
       <HintPath>..\lib\Pathfinder.dll</HintPath>
     </Reference>
@@ -76,6 +79,8 @@
     <Compile Include="Sessions\States\LsState.cs" />
     <Compile Include="Sessions\States\SessionState.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/HackOnNet/HackOnNet.csproj
+++ b/HackOnNet/HackOnNet.csproj
@@ -55,6 +55,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConfigUtil.cs" />
     <Compile Include="Daemons\Daemon.cs" />
     <Compile Include="Daemons\IRCDaemon.cs" />
     <Compile Include="DotNetCompatibility\Extensions.cs" />

--- a/HackOnNet/Net/NetManager.cs
+++ b/HackOnNet/Net/NetManager.cs
@@ -17,7 +17,7 @@ namespace HackOnNet.Net
     {
         public class StateObject
         {
-            public const int BufferSize = 512;
+            public const int BufferSize = 32000;
             public byte[] buffer = new byte[BufferSize];
             public StringBuilder sb = new StringBuilder();
         }

--- a/HackOnNet/Net/NetManager.cs
+++ b/HackOnNet/Net/NetManager.cs
@@ -9,6 +9,7 @@ using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using static HackOnNet.ConfigUtil;
 
 namespace HackOnNet.Net
 {
@@ -21,9 +22,8 @@ namespace HackOnNet.Net
             public StringBuilder sb = new StringBuilder();
         }
 
+        private const string configFile = "Mods/HNMP.conf";
         public Socket clientSocket;
-
-        private const int port = 27015;
 
         private static ManualResetEvent connectDone =
             new ManualResetEvent(false);
@@ -71,8 +71,19 @@ namespace HackOnNet.Net
             receiveDone.Reset();
             try
             {
-                var test = File.OpenText("Mods/HNMP.cfg");
-                IPEndPoint remoteEP = new IPEndPoint(IPAddress.Parse(test.ReadLine()), port);
+
+                //Create config with defaults
+                ConfigData conf = new ConfigData();
+                conf.ServerIP = "127.0.0.1";
+                conf.Port = 27015;
+
+                //Populate config from file or create config file if it's not present
+                if(!ConfigUtil.LoadConfig(configFile, conf))
+                {
+                    ConfigUtil.SaveConfig(configFile, conf);
+                }
+
+                IPEndPoint remoteEP = new IPEndPoint(IPAddress.Parse(conf.ServerIP), conf.Port);
 
                 clientSocket = new Socket(AddressFamily.InterNetwork,
                     SocketType.Stream, ProtocolType.Tcp);

--- a/HackOnNet/packages.config
+++ b/HackOnNet/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
A quick fix for an issue I encountered developing the help command. Sending messages longer than the socket read buffer size (512 bytes) would truncate the message and sometimes crash the client (because of malformed messages)
This fix increases the buffer size to 32kB which will resolve the issue until a more permanent solution can be worked on. 