### PR TITLE
Fix for ls metachar issues

### DIFF
--- a/HackLinks Server/CommandHandler.cs
+++ b/HackLinks Server/CommandHandler.cs
@@ -456,16 +456,17 @@ namespace HackLinks_Server
             }
             else
             {
-                string fileList = "";
-                foreach (var file in session.activeDirectory.children)
+                List<string> fileList = new List<string>(new string[] { "ls", session.activeDirectory.name});
+                foreach (File file in session.activeDirectory.children)
                 {
                     if (file.HasReadPermission(client.activeSession.privilege))
                     {
-                        fileList += file.name + "," + (file.IsFolder() ? "d" : "f") + ',' +
-                            (file.HasWritePermission(client.activeSession.privilege) ? "w" : "-") + ";";
+                        fileList.AddRange(new string[] {
+                                file.name, (file.IsFolder() ? "d" : "f"), (file.HasWritePermission(client.activeSession.privilege) ? "w" : "-")
+                            });
                     }
                 }
-                client.Send(NetUtil.PacketType.KERNL, "ls", session.activeDirectory.name, fileList); // ls;[working path];[listoffiles]
+                client.Send(NetUtil.PacketType.KERNL, fileList.ToArray());
                 return true;
             }
         }

--- a/HackLinks Server/Daemons/Types/DNSDaemon.cs
+++ b/HackLinks Server/Daemons/Types/DNSDaemon.cs
@@ -127,7 +127,7 @@ namespace HackLinks_Server.Daemons.Types
         {
             base.OnConnect(connectSession);
             connectSession.owner.Send(PacketType.MESSG, "Opening DNS service");
-            connectSession.owner.Send(PacketType.KERNL, "state;dns;open");
+            connectSession.owner.Send(PacketType.KERNL, "state", "dns", "open");
         }
 
         public override void OnDisconnect(Session disconnectSession)

--- a/HackOnNet/FileSystem/LsFileEntry.cs
+++ b/HackOnNet/FileSystem/LsFileEntry.cs
@@ -15,10 +15,8 @@ namespace HackOnNet.FileSystem
 
         public bool isFolder = false;
 
-        public LsFileEntry(string lsInput, int permission=0)
+        public LsFileEntry(string[] fileData, int permission=0)
         {
-            string[] fileData = lsInput.Split(',');
-
             name = fileData[0];
             isFolder = fileData[1] == "d";
             hasWritePermission = fileData[2] == "w";

--- a/HackOnNet/Screens/UserScreen.cs
+++ b/HackOnNet/Screens/UserScreen.cs
@@ -309,11 +309,11 @@ namespace HackOnNet.Screens
                 }
                 var sessionState = (LsState)activeSession.GetState();
                 sessionState.files.Clear();
-                for(int i = 2; i < command.Length; i++)
+                for(int i = 2; i < command.Length; i += 3)
                 {
                     if (command[i] == "")
                         continue;
-                    sessionState.files.Add(new LsFileEntry(command[i]));
+                    sessionState.files.Add(new LsFileEntry(command.Skip(i).Take(3).ToArray()));
                 }
                 display.state = DisplayState.LS;
             }


### PR DESCRIPTION
Some metacharacters that previously allowed the less command to work
had been left over from the previous netcode JSON conversion. This
was breaking the ls command response.