### PR TITLE
Fix server crash on loading blank files

### DIFF
--- a/HackLinks Server/FileSystem/File.cs
+++ b/HackLinks Server/FileSystem/File.cs
@@ -25,7 +25,7 @@ namespace HackLinks_Server.FileSystem
         private string name;
         private int writePriv = 0;
         private int readPriv = 0;
-        private string content;
+        private string content = "";
 
         private Folder parent;
         private int parentId;


### PR DESCRIPTION
previously file content was initialized to null when files were created
now files will be initialized to an empty string. This avoids the need
to check for null data in the content when loading from the database.