### PR TITLE
Easier inital setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -305,7 +305,4 @@ ASALocalRun/
 */bin
 
 HackOnNet/obj/*
-lib/FNA.dll
-lib/HacknetPathfinder.exe
-lib/Pathfinder.dll
 HackLinks Server/obj/*

--- a/HackOnNet/HackOnNet.csproj
+++ b/HackOnNet/HackOnNet.csproj
@@ -32,18 +32,38 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
+  <!-- Determine what libs to use -->
+  <Choose>
+    <!-- IF HackNet libs are present in lib folder -->
+    <When Condition="Exists('..\lib\HacknetPathfinder.exe')">
+      <PropertyGroup>
+        <HNPath>..\lib</HNPath>
+      </PropertyGroup>
+    </When>
+    <!-- IF HackNet is installed in under Steam and has Pathfinder.exe present -->
+    <When Condition="Exists('$(MSBuildProgramFiles32)\steam\SteamApps\common\Hacknet\HacknetPathfinder.exe')">
+      <PropertyGroup>
+        <HNPath>$(MSBuildProgramFiles32)\Steam\SteamApps\common\Hacknet</HNPath>
+      </PropertyGroup>
+    </When>
+  </Choose>
+
+  <!-- Lib References -->
   <ItemGroup>
     <Reference Include="FNA">
-      <HintPath>..\lib\FNA.dll</HintPath>
+      <HintPath>$(HNPath)\FNA.dll</HintPath>
     </Reference>
     <Reference Include="HacknetPathfinder">
-      <HintPath>..\lib\HacknetPathfinder.exe</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>$(HNPath)\HacknetPathfinder.exe</HintPath>
     </Reference>
     <Reference Include="Pathfinder">
-      <HintPath>..\lib\Pathfinder.dll</HintPath>
+      <HintPath>$(HNPath)\Pathfinder.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/HackOnNet/HackOnNet.csproj
+++ b/HackOnNet/HackOnNet.csproj
@@ -53,12 +53,15 @@
   <ItemGroup>
     <Reference Include="FNA">
       <HintPath>$(HNPath)\FNA.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="HacknetPathfinder">
       <HintPath>$(HNPath)\HacknetPathfinder.exe</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Pathfinder">
       <HintPath>$(HNPath)\Pathfinder.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/HackOnNet/HackOnNet.csproj
+++ b/HackOnNet/HackOnNet.csproj
@@ -2,6 +2,9 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
+    <SteamHNDir>$(MSBuildProgramFiles32)\steam\SteamApps\common\Hacknet</SteamHNDir>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{244411E2-786C-4B04-8F1D-E8A1DEB4AD6B}</ProjectGuid>
@@ -111,4 +114,25 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="AfterBuildSteam">
+    <Message Importance="high" Text="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" />
+    <ItemGroup>
+      <HNLibs Include="$(OutDir)\*.dll" Exclude="$(OutDir)\$(TargetFileName)" />
+    </ItemGroup>
+    <Message Importance="high" Text="== Copying Lib files &quot;@(HNLibs, ', ')&quot; to $(SteamHNDir) ==" />
+    <Copy SourceFiles="@(HNLibs)" DestinationFolder="$(SteamHNDir)" />
+    <Message Importance="high" Text="== Copying Mod file to $(SteamHNDir)\Mods ==" />
+    <Copy SourceFiles="$(OutDir)\$(TargetFileName)" DestinationFolder="$(SteamHNDir)" />
+    <Message Importance="high" Text="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" />
+  </Target>
+  <Target Name="AfterBuildNoSteam">
+    <Message Importance="high" Text="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" />
+    <Message Importance="high" Text="== WARNING: HacknetPathfinder.exe not installed under Steam ==" />
+    <Message Importance="high" Text="== Please copy the $(TargetFileName) file from $(OutDir) to the mods folder under your Hacknet Pathfinder installation directory ==" />
+    <Message Importance="high" Text="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" />
+  </Target>
+  <Target Name="AfterBuild">
+    <CallTarget Targets="AfterBuildSteam" Condition="Exists('$(SteamHNDir)\HacknetPathfinder.exe')" />
+    <CallTarget Targets="AfterBuildNoSteam" Condition="!Exists('$(SteamHNDir)\HacknetPathfinder.exe')" />
+  </Target>
 </Project>

--- a/HackOnNet/HackOnNet.csproj
+++ b/HackOnNet/HackOnNet.csproj
@@ -4,6 +4,12 @@
   <PropertyGroup>
     <SteamHNDir>$(MSBuildProgramFiles32)\steam\SteamApps\common\Hacknet</SteamHNDir>
   </PropertyGroup>
+  <!-- In debug mode we'll run the default steam install of hacknet if we can find it -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU' And Exists('$(SteamHNDir)\HacknetPathfinder.exe')">
+    <StartAction>Program</StartAction>
+    <StartProgram>$(MSBuildProgramFiles32)\Steam\SteamApps\common\Hacknet\HacknetPathfinder.exe</StartProgram>
+    <StartWorkingDirectory>$(MSBuildProgramFiles32)\Steam\SteamApps\common\Hacknet\</StartWorkingDirectory>
+  </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/HackOnNet/HackOnNet.csproj
+++ b/HackOnNet/HackOnNet.csproj
@@ -38,29 +38,28 @@
     <!-- IF HackNet libs are present in lib folder -->
     <When Condition="Exists('..\lib\HacknetPathfinder.exe')">
       <PropertyGroup>
-        <HNPath>..\lib</HNPath>
+        <HNLibPath>..\lib</HNLibPath>
       </PropertyGroup>
     </When>
     <!-- IF HackNet is installed in under Steam and has Pathfinder.exe present -->
     <When Condition="Exists('$(MSBuildProgramFiles32)\steam\SteamApps\common\Hacknet\HacknetPathfinder.exe')">
       <PropertyGroup>
-        <HNPath>$(MSBuildProgramFiles32)\Steam\SteamApps\common\Hacknet</HNPath>
+        <HNLibPath>$(MSBuildProgramFiles32)\Steam\SteamApps\common\Hacknet</HNLibPath>
       </PropertyGroup>
     </When>
   </Choose>
-
   <!-- Lib References -->
   <ItemGroup>
     <Reference Include="FNA">
-      <HintPath>$(HNPath)\FNA.dll</HintPath>
+      <HintPath>$(HNLibPath)\FNA.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HacknetPathfinder">
-      <HintPath>$(HNPath)\HacknetPathfinder.exe</HintPath>
+      <HintPath>$(HNLibPath)\HacknetPathfinder.exe</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Pathfinder">
-      <HintPath>$(HNPath)\Pathfinder.dll</HintPath>
+      <HintPath>$(HNLibPath)\Pathfinder.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except this file and the README
+!.gitignore
+!README.md

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,15 @@
+# External Libs Folder
+
+This folder shouldn't need to be touched in most cases.
+It serves to allow developers to override the default behavior of referencing the following files
+under ```%ProgramFiles(x86)%\Steam\SteamApps\common\Hacknet\```
+* ```FNA.dll```
+* ```"HacknetPathfinder.exe```
+* ```"Pathfinder.dll"```
+
+This might be required for a number of reasons, for example you obtained your copy of Hacknet from a different distribution platform.
+
+## Usage
+
+To Make use of this folder simply place a copy of each file listed above within this directory.
+The presence of ```HacknetPathfinder.exe``` will instruct the system to make use of the files provided here instead.


### PR DESCRIPTION
I've altered the project files to make it easier to begin development.
It should be possible to compile and launch HackOnNet and HackLinks Server now without copying files into the libs folder, copying the compiled files or tinkering with configurations.

The main caveat is that this has been developed with Steam+Windows installation in mind but it should be extendible for other platform+system combinations (if there's enough interest in another platform or system I volunteer to make said changes) 
Manual configuration for the altered settings through visual studio should override/mask most of these changes with the *.csproj.user file contents and alternate HN Libs can simply be placed in the libs folder and work as they previously have done.
