### PR TITLE
Fix typo/bug in mod install build target

### DIFF
--- a/HackOnNet/HackOnNet.csproj
+++ b/HackOnNet/HackOnNet.csproj
@@ -128,7 +128,7 @@
     <Message Importance="high" Text="== Copying Lib files &quot;@(HNLibs, ', ')&quot; to $(SteamHNDir) ==" />
     <Copy SourceFiles="@(HNLibs)" DestinationFolder="$(SteamHNDir)" />
     <Message Importance="high" Text="== Copying Mod file to $(SteamHNDir)\Mods ==" />
-    <Copy SourceFiles="$(OutDir)\$(TargetFileName)" DestinationFolder="$(SteamHNDir)" />
+    <Copy SourceFiles="$(OutDir)\$(TargetFileName)" DestinationFolder="$(SteamHNDir)\Mods" />
     <Message Importance="high" Text="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" />
   </Target>
   <Target Name="AfterBuildNoSteam">


### PR DESCRIPTION
The mod file was being copied to Steam\SteamApps\Common\Hacknet instead
of Steam\SteamApps\Common\Hacknet\Mods.