### PR TITLE
Fix missing Permissions.cs file

### DIFF
--- a/HackLinks Server/HackLinks Server.csproj
+++ b/HackLinks Server/HackLinks Server.csproj
@@ -63,7 +63,6 @@
   <ItemGroup>
     <Compile Include="CommandHandler.cs" />
     <Compile Include="Computers\Groups.cs" />
-    <Compile Include="Computers\Permissions.cs" />
     <Compile Include="Computers\ComputerManager.cs" />
     <Compile Include="Computers\Files\FileSystemManager.cs" />
     <Compile Include="Computers\Files\FileSystem.cs" />


### PR DESCRIPTION
This file was mistakenly listed in the build files. It doesn't exist.
This fix removes the entry from the build files.