### PR TITLE
Fix for inconsistent order of permissions

### DIFF
--- a/HackLinks Server/Computers/FilePermissions.cs
+++ b/HackLinks Server/Computers/FilePermissions.cs
@@ -65,11 +65,11 @@ namespace HackLinks_Server.Computers
         /// Check if the file has permission for the given operations for the given type.
         /// </summary>
         /// <param name="type">The <see cref="PermissionType"/> to check</param>
-        /// <param name="execute">Set true if you want to check execute permission</param>
-        /// <param name="write">Set true if you want to check write permission</param>
         /// <param name="read">Set true if you want to check read permission</param>
+        /// <param name="write">Set true if you want to check write permission</param>
+        /// <param name="execute">Set true if you want to check execute permission</param>
         /// <returns>True if the type would have permission to perform the operation, false otherwise</returns>
-        public bool CheckPermission(PermissionType type, bool execute, bool write, bool read)
+        public bool CheckPermission(PermissionType type, bool read, bool write, bool execute)
         {
             return CheckPermissionDigit(type, CalculatePermissionDigit(read, write, execute));
         }

--- a/HackLinks Server/Computers/Files/File.cs
+++ b/HackLinks Server/Computers/Files/File.cs
@@ -132,7 +132,7 @@ namespace HackLinks_Server.Files
 
         public bool HasExecutePermission(string username, Group priv)
         {
-            return HasPermission(username, priv, true, false, false);
+            return HasPermission(username, priv, false, false, true);
         }
 
         public bool HasWritePermission(string username, Group priv)
@@ -142,12 +142,12 @@ namespace HackLinks_Server.Files
 
         public bool HasReadPermission(string username, Group priv)
         {
-            return HasPermission(username, priv, false, false, true);
+            return HasPermission(username, priv, true, false, false);
         }
 
         public bool HasExecutePermission(string username, List<Group> privs)
         {
-            return HasPermission(username, privs, true, false, false);
+            return HasPermission(username, privs, false, false, true);
         }
 
         public bool HasWritePermission(string username, List<Group> privs)
@@ -157,19 +157,19 @@ namespace HackLinks_Server.Files
 
         public bool HasReadPermission(string username, List<Group> privs)
         {
-            return HasPermission(username, privs, false, false, true);
+            return HasPermission(username, privs, true, false, false);
         }
 
-        public bool HasPermission(string username, Group priv, bool execute, bool write, bool read)
+        public bool HasPermission(string username, Group priv, bool read, bool write, bool execute)
         {
-            return HasPermission(username,new List<Group> { priv }, execute, read, write);
+            return HasPermission(username,new List<Group> { priv }, read, write, execute);
         }
 
-        public bool HasPermission(string username, List<Group> privs, bool execute, bool write, bool read)
+        public bool HasPermission(string username, List<Group> privs, bool read, bool write, bool execute)
         {
             if (privs.Contains(Group))
             {
-                if (Permissions.CheckPermission(FilePermissions.PermissionType.Group, execute, write, read))
+                if (Permissions.CheckPermission(FilePermissions.PermissionType.Group, read, write, execute))
                 {
                     return true;
                 }
@@ -177,13 +177,13 @@ namespace HackLinks_Server.Files
 
             if (OwnerUsername == username)
             {
-                if (Permissions.CheckPermission(FilePermissions.PermissionType.User, execute, write, read))
+                if (Permissions.CheckPermission(FilePermissions.PermissionType.User, read, write, execute))
                 {
                     return true;
                 }
             }
 
-            return Permissions.CheckPermission(FilePermissions.PermissionType.Others, execute, write, read);
+            return Permissions.CheckPermission(FilePermissions.PermissionType.Others, read, write, execute);
         }
 
         virtual public bool IsFolder()


### PR DESCRIPTION
Some functions took permissions in the form RWX and some took it as
XWR. This was non-obvious when looking at the signature and was easy to
confuse and cause errors.