### PR TITLE
Add Application Files

### DIFF
--- a/HackLinks Server/Computers/CompiledFileManager.cs
+++ b/HackLinks Server/Computers/CompiledFileManager.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace HackLinks_Server
+{
+    public class CompiledFileManager
+    {
+        private Dictionary<int, string> types = new Dictionary<int, string>();
+
+        public void AddType(int checksum, string type)
+        {
+            types.Add(checksum, type);
+        }
+
+        public string GetType(int checksum)
+        {
+            return types.ContainsKey(checksum) ? types[checksum] : "False";
+        }
+
+        public Dictionary<int, string> GetMap()
+        {
+            // We return a shallow clone here to prevent unauthorized manipulation of the map
+            return new Dictionary<int, string>(types);
+        }
+    }
+}

--- a/HackLinks Server/Computers/Files/File.cs
+++ b/HackLinks Server/Computers/Files/File.cs
@@ -47,7 +47,8 @@ namespace HackLinks_Server.Files
 
         public Group Group { get => group; set { group = value; Dirty = true; } }
 
-        public string Content { get => content; set { content = value; Dirty = true;  } }
+        public string Content { get => content; set { content = value; Dirty = true; Checksum = content.GetHashCode(); } } // TODO make hash function portable/low collision eg. https://softwareengineering.stackexchange.com/questions/49550/which-hashing-algorithm-is-best-for-uniqueness-and-speed
+        public int Checksum { get; private set; }
 
         public int ParentId { get => parentId; set { parentId = value; Dirty = true; } }
         public int ComputerId { get => computerId; set { computerId = value; Dirty = true; } }

--- a/HackLinks Server/Computers/Kernel.cs
+++ b/HackLinks Server/Computers/Kernel.cs
@@ -135,6 +135,14 @@ namespace HackLinks_Server.Computers
             GetClient(process).server.GetComputerManager().AddToDelete(file);
         }
 
+        public Process StartProcess(Process process, File file)
+        {
+            if(!file.HasExecutePermission(process.Credentials))
+                StartProcess(process, "False");
+            string type = GetClient(process).server.GetCompileManager().GetType(file.Checksum);
+            return StartProcess(process, type);
+        }
+
         public Process StartProcess(Process process, string type)
         {
             // TODO clone credentials OR make sure they're imutable

--- a/HackLinks Server/Computers/Processes/False.cs
+++ b/HackLinks Server/Computers/Processes/False.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HackLinks_Server.Computers.Processes
+{
+    public class False : Process
+    {
+        public False(int pid, Printer printer, Node computer, Credentials credentials) : base(pid, printer, computer, credentials)
+        {
+        }
+
+        public override void Run(string command)
+        {
+            base.Run(command);
+            CurrentState = State.Dead;
+            exitCode = 1; // non-zero exitcode
+        }
+    }
+}

--- a/HackLinks Server/Database/DatabaseDump.cs
+++ b/HackLinks Server/Database/DatabaseDump.cs
@@ -99,9 +99,40 @@ namespace HackLinks_Server.Database
             "',1,1,774,0),"+
             "(8,'bank',2,0,1,'BANK',1,0,774,0)," +
             "(9,'bank',1,1,1,'bank',1,0,774,0)," +
-            "(10,'accounts.db',9,0,1,'',1,0,774,0)",
+            "(10,'accounts.db',9,0,1,'',1,0,774,0)," +
+            "(11,'bin',1,1,0,'',1,0,774,0)," +
+            "(0,'hackybox',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'ping',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'connect',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'disconnect',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'dc',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'ls',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'touch',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'view',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'mkdir',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'rm',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'login',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'chown',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'chmod',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'fedit',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'netmap',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'music',11,0,0,'hackybox',1,0,774,0),"+
+            "(0,'admin',11,0,0,'serveradmin',1,0,774,0)",
             "/*!40000 ALTER TABLE `files` ENABLE KEYS */",
+
             "UNLOCK TABLES",
+            "DROP TABLE IF EXISTS `binaries`",
+            "CREATE TABLE `binaries` (" +
+            " `id` int(11) PRIMARY KEY NOT NULL AUTO_INCREMENT," +
+            " `checksum` int NOT NULL," +
+            " `type` char(64) NOT NULL" +
+            ") ENGINE = InnoDB AUTO_INCREMENT = 1 DEFAULT CHARSET = latin1",
+            //
+            // Dumping data for table `binaries`
+            //
+            $"INSERT INTO `binaries` VALUES "+
+            $"(0,{"hackybox".GetHashCode()},'Hackybox'),"+
+            $"(0,{"serveradmin".GetHashCode()},'ServerAdmin')",
         };
 
         public static List<string> Commands => commands;

--- a/HackLinks Server/Database/DatabaseLink.cs
+++ b/HackLinks Server/Database/DatabaseLink.cs
@@ -102,6 +102,20 @@ namespace HackLinks_Server.Database
                 }
             }
 
+            using (MySqlConnection conn = new MySqlConnection(GetConnectionString()))
+            {
+                conn.Open();
+                MySqlCommand command = new MySqlCommand("SELECT checksum, type FROM binaries", conn);
+
+                using (MySqlDataReader reader = command.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        Server.Instance.GetCompileManager().AddType(reader.GetInt32("checksum"), reader.GetString("type"));
+                    }
+                }
+            }
+
             return nodeList;
         }
 

--- a/HackLinks Server/GameClient.cs
+++ b/HackLinks Server/GameClient.cs
@@ -74,7 +74,15 @@ namespace HackLinks_Server
         private Process CreateProcess(Node node, Type type, Credentials credentials, Process.Printer printer)
         {
             Console.WriteLine(type);
-            return (Process)Activator.CreateInstance(type, new object[] { node.NextPID, printer, node, credentials });
+            object[] args;
+            if( type == typeof(ServerAdmin))
+            {
+                args = new object[] { node.NextPID, printer, node, credentials, this };
+            } else
+            {
+                args = new object[] { node.NextPID, printer, node, credentials };
+            }
+            return (Process)Activator.CreateInstance(type, args);
         }
 
         public void Disconnect()

--- a/HackLinks Server/HackLinks Server.csproj
+++ b/HackLinks Server/HackLinks Server.csproj
@@ -61,10 +61,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Computers\CompiledFileManager.cs" />
     <Compile Include="Computers\Kernel.cs" />
     <Compile Include="Computers\Processes\BankClient.cs" />
     <Compile Include="Computers\Processes\CommandProcess.cs" />
     <Compile Include="Computers\Processes\Credentials.cs" />
+    <Compile Include="Computers\Processes\False.cs" />
     <Compile Include="Computers\Processes\Hackybox.cs" />
     <Compile Include="Computers\Processes\HASH.cs" />
     <Compile Include="Computers\Processes\Process.cs" />

--- a/HackLinks Server/Server.cs
+++ b/HackLinks Server/Server.cs
@@ -22,6 +22,7 @@ namespace HackLinks_Server
 
         private ComputerManager computerManager;
         private FileSystemManager fileSystemManager = new FileSystemManager();
+        private CompiledFileManager compileManager = new CompiledFileManager();
 
         public FileSystemManager FileSystemManager => fileSystemManager;
 
@@ -145,6 +146,11 @@ namespace HackLinks_Server
                     client.activeSession.UpdateTrace(dT);
                 }
             }
+        }
+
+        public CompiledFileManager GetCompileManager()
+        {
+            return compileManager;
         }
 
         internal void SaveDatabase()


### PR DESCRIPTION
This adds a new DB table to store a mapping between file checksum and
process type. This allows users to "compile" softwares to files.
Currently only admins may create them in game using the "compile"
command from the ServerAdmin process.