### PR TITLE
Fix for help command not being processed for HASH

### DIFF
--- a/HackLinks Server/Computers/Processes/CommandProcess.cs
+++ b/HackLinks Server/Computers/Processes/CommandProcess.cs
@@ -25,7 +25,6 @@ namespace HackLinks_Server.Computers.Processes
                 return Help(commandParts);
             if (Commands.ContainsKey(commandParts[0]))
                 return Commands[commandParts[0]].Item2(this, commandParts);
-            Print($"Invalid Command: '{command}'");
             return false;
         }
 

--- a/HackLinks Server/Computers/Processes/HASH.cs
+++ b/HackLinks Server/Computers/Processes/HASH.cs
@@ -24,13 +24,7 @@ namespace HackLinks_Server.Computers.Processes
 
         public bool HandleBuiltin(string command)
         {
-            string[] commandParts = command.Split(new char[] { ' ' }, 2);
-            if (Commands.ContainsKey(commandParts[0]))
-            {
-                Commands[commandParts[0]].Item2(this, commandParts);
-                return true;
-            }
-            return false;
+            return RunCommand(command);
         }
 
         private bool HandleExternal(string command)


### PR DESCRIPTION
The help command is provided by the CommandProcess Class. It wasn't being called correctly when handling Shell Builtins