### PR TITLE
Fix for failed build when DiscordRPC dll is missing

### DIFF
--- a/HackOnNet/HackOnNet.csproj
+++ b/HackOnNet/HackOnNet.csproj
@@ -126,11 +126,6 @@
       <Name>HackLinksCommon</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="DiscordRP\discord-rpc.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </EmbeddedResource>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuildSteam">
     <Message Importance="high" Text="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~" />


### PR DESCRIPTION
This DLL isn't required at build time as it's loaded dynamically at
execution.