### PR TITLE
Fix client not closing socket before disconnecting

### DIFF
--- a/HackOnNet/Net/NetManager.cs
+++ b/HackOnNet/Net/NetManager.cs
@@ -33,8 +33,8 @@ namespace HackOnNet.Net
             new ManualResetEvent(false);
 
         private static String response = String.Empty;
-        private static bool disconnectHandled = false;
 
+        private bool disconnectHandled = false;
         public UserScreen userScreen;
         public string nodesToSync = "";
         public bool gotNodes = false;
@@ -60,11 +60,16 @@ namespace HackOnNet.Net
             Disconnect(isInGame, "Connection Lost");
         }
 
-        public void Disconnect(bool isInGame, string reason)
+        public void Disconnect(bool isInGame, string reason, bool leftGame = false)
         {
             if (!disconnectHandled)
             {
                 reason = string.IsNullOrWhiteSpace(reason) ? "The server or client did not provide a reason for disconnection" : reason;
+                if (leftGame)
+                {
+                    disconnectHandled = true;
+                    reason = "";
+                }
                 clientSocket.Close();
                 if (isInGame)
                     userScreen.quitGame(this, reason);

--- a/HackOnNet/Screens/UserScreen.cs
+++ b/HackOnNet/Screens/UserScreen.cs
@@ -316,7 +316,7 @@ namespace HackOnNet.Screens
             {
                 this.ExitToMenuMessageBox = new MessageBoxScreen("Logout of your\nCurrent Session?" + "\n", false, true);
                 this.ExitToMenuMessageBox.OverrideAcceptedText = LocaleTerms.Loc("Exit to Menu");
-                this.ExitToMenuMessageBox.Accepted += new System.EventHandler<PlayerIndexEventArgs>(this.quitGame);
+                this.ExitToMenuMessageBox.Accepted += new System.EventHandler<PlayerIndexEventArgs>(this.QuitToOG);
                 base.ScreenManager.AddScreen(this.ExitToMenuMessageBox);
             }
             else
@@ -484,6 +484,12 @@ namespace HackOnNet.Screens
             {
                 Console.WriteLine(ex.Message);
             }
+        }
+
+        public void QuitToOG(object sender, PlayerIndexEventArgs e)
+        {
+            netManager.Send(NetUtil.PacketType.DSCON);
+            netManager.Disconnect(true, "", true);
         }
 
         public void quitGame(object sender, PlayerIndexEventArgs e)


### PR DESCRIPTION
Before this fix, the client used to just go back to the menu without disconnecting the socket or whatsoever. This will create problems like trace not stopping. For example, if you disconnected while you were being traced, the trace timer wouldn't stop when you disconnected and you'll continue being traced then a data reset would happen, not great for the user.