### PR TITLE
Node Login Fix

### DIFF
--- a/HackOnNet/Modules/OnNetDisplayModule.cs
+++ b/HackOnNet/Modules/OnNetDisplayModule.cs
@@ -193,7 +193,16 @@ namespace HackOnNet.Modules
             }
             if (Hacknet.Gui.Button.doButton(300000, this.x, this.y, 300, num2, LocaleTerms.Loc("Login"), this.userScreen.highlightColor))
             {
-                this.userScreen.Execute("login");
+                //Sets prefixcommand inside of OnNetTerminal.cs so that when you press the login button it asks for a username and password and does login (user) (pass) instead of using (user) and (pass) as a commmand.
+                //You can prob use prefixcommand for more then just this.
+                userScreen.terminal.currentLine = "";
+                userScreen.terminal.prefixcommand = "login";
+                Hacknet.Gui.TextBox.cursorPosition = 0;
+                Hacknet.Gui.TextBox.textDrawOffsetPosition = 0;
+                userScreen.terminal.executionPreventionIsInteruptable = false;
+
+                //VVV What i found when i got here VVV
+                //this.userScreen.Execute("login");
             }
             this.y += num2 + 5;
             /*if (Hacknet.Gui.Button.doButton(300002, this.x, this.y, 300, num2, LocaleTerms.Loc("Probe System"), new Color?(this.userScreen.highlightColor)))

--- a/HackOnNet/Modules/OnNetDisplayModule.cs
+++ b/HackOnNet/Modules/OnNetDisplayModule.cs
@@ -196,6 +196,7 @@ namespace HackOnNet.Modules
                 //Sets prefixcommand inside of OnNetTerminal.cs so that when you press the login button it asks for a username and password and does login (user) (pass) instead of using (user) and (pass) as a commmand.
                 //You can prob use prefixcommand for more then just this.
                 userScreen.terminal.currentLine = "";
+                userScreen.terminal.writeLine("(Username) (Password)");
                 userScreen.terminal.prefixcommand = "login";
                 Hacknet.Gui.TextBox.cursorPosition = 0;
                 Hacknet.Gui.TextBox.textDrawOffsetPosition = 0;

--- a/HackOnNet/Modules/OnNetTerminal.cs
+++ b/HackOnNet/Modules/OnNetTerminal.cs
@@ -27,6 +27,8 @@ namespace HackOnNet.Modules
 
         public string prompt;
 
+        public string prefixcommand;
+
         public bool usingTabExecution = false;
 
         public bool preventingExecution = false;
@@ -203,7 +205,26 @@ namespace HackOnNet.Modules
                     this.currentLine = Hacknet.Gui.TextBox.doTerminalTextField(7001, this.bounds.X + 3 + (int)Terminal.PROMPT_OFFSET + (int)tinyfont.MeasureString(this.prompt.RemoveFormatting()).X, num2, this.bounds.Width - i - 4, this.bounds.Height, 1, this.currentLine, tinyfont);
                     if (Hacknet.Gui.TextBox.BoxWasActivated)
                     {
-                        this.executeLine();
+                        //prefixcommand is used to make sure that commands which require a second level of input into the terminal not run the second level arguments as a seperate command.
+                        //prefixcommand should be stuff like "login" or "help".
+                        //prefixcommand is set in OnNetDisplayModule.cs.
+                        if (prefixcommand == null)
+                        {
+                            this.executeLine();
+                        }
+                        else
+                        {
+                            this.currentLine = prefixcommand + ' ' + this.currentLine;
+                            this.executeLine();
+                            //whenever the login buttin was pressed, it would auto execute line and reset prefix command so it would treat the second level as an arugment anyways, so
+                            //to combat this i checked if the previous executed command was a nothing command.
+                            if(this.lastRunCommand != "" && prefixcommand != null)
+                            {
+                                prefixcommand = null;
+                            }
+
+                        }
+
                     }
                     if (Hacknet.Gui.TextBox.UpWasPresed)
                     {


### PR DESCRIPTION
Added a prefixcommand string inside of OnNetTerminal.cs inside of HackOnNet/Modules that can be used to get a second level of input, i used this to make the login button on a node ask for a username and password instead of just doing "login" as a command. prefixcommand is set inside of OnNetDisplayModule.cs inside of HackOnNet/Modules inside of the private void doConnectDisplay()