### PR TITLE
Made Node Login use server process

### DIFF
--- a/HackLinks Server/Computers/Kernel.cs
+++ b/HackLinks Server/Computers/Kernel.cs
@@ -43,15 +43,25 @@ namespace HackLinks_Server.Computers
         public void Login(CommandProcess process, string username, string password)
         {
             GameClient client = GetClient(process);
-            Credentials credentials = node.Login(GetClient(process), username, password);
-            if (credentials != null)
+            if (username == "" && password == "")
             {
-                client.Login(node, credentials);
-                client.Send(NetUtil.PacketType.MESSG, "Logged as : " + username);
-                node.Log(Log.LogEvents.Login, node.logs.Count + 1 + " " + client.homeComputer.ip + " logged in as " + username, client.activeSession.sessionId, client.homeComputer.ip);
-            } else
+                //client.Send(NetUtil.PacketType.MESSG, "(Username) (Password)");
+                client.Send(NetUtil.PacketType.KERNL, "login", "prefixcommand");
+
+            }
+            else
             {
-                client.Send(NetUtil.PacketType.MESSG, "Wrong identificants.");
+                Credentials credentials = node.Login(GetClient(process), username, password);
+                if (credentials != null)
+                {
+                    client.Login(node, credentials);
+                    client.Send(NetUtil.PacketType.MESSG, "Logged as : " + username);
+                    node.Log(Log.LogEvents.Login, node.logs.Count + 1 + " " + client.homeComputer.ip + " logged in as " + username, client.activeSession.sessionId, client.homeComputer.ip);
+                }
+                else
+                {
+                    client.Send(NetUtil.PacketType.MESSG, "Wrong identificants.");
+                }
             }
         }
 

--- a/HackLinks Server/Computers/Processes/Hackybox.cs
+++ b/HackLinks Server/Computers/Processes/Hackybox.cs
@@ -329,7 +329,8 @@ namespace HackLinks_Server.Computers.Processes
         {
             if (command.Length < 2)
             {
-                process.Print("Usage : login [username] [password]");
+                process.computer.Kernel.Login(process, "", "");
+               //process.Print("Usage : login [username] [password]");
                 return true;
             }
             var args = command[1].Split(' ');

--- a/HackOnNet/Modules/OnNetDisplayModule.cs
+++ b/HackOnNet/Modules/OnNetDisplayModule.cs
@@ -193,7 +193,16 @@ namespace HackOnNet.Modules
             }
             if (Hacknet.Gui.Button.doButton(300000, this.x, this.y, 300, num2, LocaleTerms.Loc("Login"), this.userScreen.highlightColor))
             {
-                this.userScreen.Execute("login");
+                //Sets prefixcommand inside of OnNetTerminal.cs so that when you press the login button it asks for a username and password and does login (user) (pass) instead of using (user) and (pass) as a commmand.
+                //You can prob use prefixcommand for more then just this.
+                userScreen.terminal.currentLine = "";
+                userScreen.terminal.prefixcommand = "login";
+                Hacknet.Gui.TextBox.cursorPosition = 0;
+                Hacknet.Gui.TextBox.textDrawOffsetPosition = 0;
+                userScreen.terminal.executionPreventionIsInteruptable = false;
+
+                //VVV What i found when i got here VVV
+                //this.userScreen.Execute("login");
             }
             this.y += num2 + 5;
             /*if (Hacknet.Gui.Button.doButton(300002, this.x, this.y, 300, num2, LocaleTerms.Loc("Probe System"), new Color?(this.userScreen.highlightColor)))

--- a/HackOnNet/Modules/OnNetDisplayModule.cs
+++ b/HackOnNet/Modules/OnNetDisplayModule.cs
@@ -193,14 +193,17 @@ namespace HackOnNet.Modules
             }
             if (Hacknet.Gui.Button.doButton(300000, this.x, this.y, 300, num2, LocaleTerms.Loc("Login"), this.userScreen.highlightColor))
             {
+                userScreen.netManager.Send(HackLinksCommon.NetUtil.PacketType.COMND, "login");
+
+
                 //Sets prefixcommand inside of OnNetTerminal.cs so that when you press the login button it asks for a username and password and does login (user) (pass) instead of using (user) and (pass) as a commmand.
                 //You can prob use prefixcommand for more then just this.
-                userScreen.terminal.currentLine = "";
-                userScreen.terminal.writeLine("(Username) (Password)");
-                userScreen.terminal.prefixcommand = "login";
-                Hacknet.Gui.TextBox.cursorPosition = 0;
-                Hacknet.Gui.TextBox.textDrawOffsetPosition = 0;
-                userScreen.terminal.executionPreventionIsInteruptable = false;
+                //userScreen.terminal.currentLine = "";
+                //userScreen.terminal.writeLine("(Username) (Password)");
+                //userScreen.terminal.prefixcommand = "login";
+                //Hacknet.Gui.TextBox.cursorPosition = 0;
+                //Hacknet.Gui.TextBox.textDrawOffsetPosition = 0;
+                //userScreen.terminal.executionPreventionIsInteruptable = false;
 
                 //VVV What i found when i got here VVV
                 //this.userScreen.Execute("login");

--- a/HackOnNet/Modules/OnNetDisplayModule.cs
+++ b/HackOnNet/Modules/OnNetDisplayModule.cs
@@ -196,6 +196,7 @@ namespace HackOnNet.Modules
                 //Sets prefixcommand inside of OnNetTerminal.cs so that when you press the login button it asks for a username and password and does login (user) (pass) instead of using (user) and (pass) as a commmand.
                 //You can prob use prefixcommand for more then just this.
                 userScreen.terminal.currentLine = "";
+                userScreen.terminal.writeLine("(Username) (Password)");
                 userScreen.terminal.prefixcommand = "login";
                 Hacknet.Gui.TextBox.cursorPosition = 0;
                 Hacknet.Gui.TextBox.textDrawOffsetPosition = 0;

--- a/HackOnNet/Modules/OnNetTerminal.cs
+++ b/HackOnNet/Modules/OnNetTerminal.cs
@@ -27,6 +27,8 @@ namespace HackOnNet.Modules
 
         public string prompt;
 
+        public string prefixcommand;
+
         public bool usingTabExecution = false;
 
         public bool preventingExecution = false;
@@ -203,7 +205,26 @@ namespace HackOnNet.Modules
                     this.currentLine = Hacknet.Gui.TextBox.doTerminalTextField(7001, this.bounds.X + 3 + (int)Terminal.PROMPT_OFFSET + (int)tinyfont.MeasureString(this.prompt.RemoveFormatting()).X, num2, this.bounds.Width - i - 4, this.bounds.Height, 1, this.currentLine, tinyfont);
                     if (Hacknet.Gui.TextBox.BoxWasActivated)
                     {
-                        this.executeLine();
+                        //prefixcommand is used to make sure that commands which require a second level of input into the terminal not run the second level arguments as a seperate command.
+                        //prefixcommand should be stuff like "login" or "help".
+                        //prefixcommand is set in OnNetDisplayModule.cs.
+                        if (prefixcommand == null)
+                        {
+                            this.executeLine();
+                        }
+                        else
+                        {
+                            this.currentLine = prefixcommand + ' ' + this.currentLine;
+                            this.executeLine();
+                            //whenever the login buttin was pressed, it would auto execute line and reset prefix command so it would treat the second level as an arugment anyways, so
+                            //to combat this i checked if the previous executed command was a nothing command.
+                            if(this.lastRunCommand != "" && prefixcommand != null)
+                            {
+                                prefixcommand = null;
+                            }
+
+                        }
+
                     }
                     if (Hacknet.Gui.TextBox.UpWasPresed)
                     {

--- a/HackOnNet/Screens/UserScreen.cs
+++ b/HackOnNet/Screens/UserScreen.cs
@@ -414,8 +414,20 @@ namespace HackOnNet.Screens
             }
             else if(command[0] == "login")
             {
-                activeSession.privilege = int.Parse(command[1]);
-                activeSession.accountName = command[2];
+                if (command[1] == "prefixcommand")
+                {
+                    this.terminal.writeLine("(Username) (Password)");
+                    this.terminal.currentLine = "";
+                    this.terminal.prefixcommand = "login";
+                    Hacknet.Gui.TextBox.cursorPosition = 0;
+                    Hacknet.Gui.TextBox.textDrawOffsetPosition = 0;
+                    this.terminal.executionPreventionIsInteruptable = false;
+                }
+                else
+                {
+                    activeSession.privilege = int.Parse(command[1]);
+                    activeSession.accountName = command[2];
+                }
             }
             else if(command[0] == "state")
             {


### PR DESCRIPTION
Made it so instead of it all being done clientside for the node login button, it sends just "login" to the server without a username or password, and i changed the server so when it gets just "login" it will send a message to the client to request a username and password by sending the string array as "login", "prefixcommand", when the client receives this it will set the prefixcommand inside of the OnTerminalDisplay.cs making it do the node login like it did before